### PR TITLE
PE-49 fix app_service subnet apply from scratch

### DIFF
--- a/code/api.tf
+++ b/code/api.tf
@@ -54,7 +54,8 @@ module "portal_backend_1" {
   allowed_subnets = [module.subnet_public.id]
   allowed_ips     = []
 
-  subnet_id = module.subnet_api.id
+  subnet_name = module.subnet_api.name
+  subnet_id   = module.subnet_api.id
 
   tags = var.tags
 }

--- a/modules/app_service/README.md
+++ b/modules/app_service/README.md
@@ -39,6 +39,7 @@ No modules.
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | `"westeurope"` | no |
 | <a name="input_sku"></a> [sku](#input\_sku) | n/a | <pre>object({<br>    tier     = string<br>    size     = string<br>    capacity = number<br>  })</pre> | <pre>{<br>  "capacity": 1,<br>  "size": "S1",<br>  "tier": "Standard"<br>}</pre> | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet id wether you want to integrate the app service to a subnet. | `string` | `null` | no |
+| <a name="input_subnet_name"></a> [subnet\_name](#input\_subnet\_name) | Subnet name wether you want to integrate the app service to a subnet. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(any)` | <pre>{<br>  "CreatedBy": "Terraform"<br>}</pre> | no |
 
 ## Outputs

--- a/modules/app_service/main.tf
+++ b/modules/app_service/main.tf
@@ -73,7 +73,7 @@ resource "azurerm_app_service" "app_service" {
 }
 
 resource "azurerm_app_service_virtual_network_swift_connection" "app_service_virtual_network_swift_connection" {
-  count = var.subnet_id == null ? 0 : 1
+  count = var.subnet_name != null ? 1 : 0
 
   app_service_id = azurerm_app_service.app_service.id
   subnet_id      = var.subnet_id

--- a/modules/app_service/variables.tf
+++ b/modules/app_service/variables.tf
@@ -74,11 +74,17 @@ variable "allowed_ips" {
   default     = []
 }
 
+variable "subnet_name" {
+  type        = string
+  description = "Subnet name wether you want to integrate the app service to a subnet."
+  default     = null
+}
+
+
 variable "subnet_id" {
   type        = string
   description = "Subnet id wether you want to integrate the app service to a subnet."
   default     = null
-
 }
 
 variable "tags" {


### PR DESCRIPTION

```
Error: Invalid count argument

  on ../modules/app_service/main.tf line 76, in resource "azurerm_app_service_virtual_network_swift_connection" "app_service_virtual_network_swift_connection":
  76:   count = var.subnet_id == null ? 0 : 1

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```