### PR TITLE
[#IOINFRA-81] Remove application_id in cert_renew_policy

### DIFF
--- a/code/modules/app_function/main.tf
+++ b/code/modules/app_function/main.tf
@@ -22,6 +22,7 @@ resource "azurerm_storage_account" "this" {
   location                 = var.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
 
   tags = var.tags
 }

--- a/code/security.tf
+++ b/code/security.tf
@@ -104,11 +104,10 @@ resource "azurerm_key_vault_access_policy" "ad_group_policy" {
 
 # azure devops
 resource "azurerm_key_vault_access_policy" "cert_renew_policy" {
-  count          = var.cert_renew_app_object_id == null ? 0 : 1
-  key_vault_id   = azurerm_key_vault.key_vault.id
-  tenant_id      = data.azurerm_client_config.current.tenant_id
-  object_id      = var.cert_renew_app_object_id
-  application_id = var.cert_renew_app_id
+  count        = var.cert_renew_app_object_id == null ? 0 : 1
+  key_vault_id = azurerm_key_vault.key_vault.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = var.cert_renew_app_object_id
 
   key_permissions = [
     "Get",

--- a/code/variables.tf
+++ b/code/variables.tf
@@ -99,7 +99,7 @@ variable "cidr_subnet_spid_login" {
 }
 
 variable "cidr_subnet_ade_aa_mock" {
-  type = list(string)
+  type    = list(string)
   default = null
 }
 
@@ -313,6 +313,6 @@ variable "enable_spid_test" {
 
 # ADE
 variable "enable_ade_aa_mock" {
-  type = bool
+  type    = bool
   default = false
 }


### PR DESCRIPTION
- application_id in cert_renew_policy causes a fail in cert-az-pipeline
- also fixed security enhancement min_tls_version = "TLS1_2" to function_storage account