### PR TITLE
[#IC-336] Add Redis cache to Operator Search

### DIFF
--- a/code/api.tf
+++ b/code/api.tf
@@ -364,6 +364,11 @@ locals {
 
     CDN_MERCHANT_IMAGES_BASE_URL = format("https://%s", module.cdn_portal_storage.hostname)
 
+    # REDIS
+    REDIS_URL      = module.redis_cache.hostname
+    REDIS_PORT     = module.redis_cache.ssl_port
+    REDIS_PASSWORD = module.redis_cache.primary_access_key
+
   }
 }
 

--- a/code/api.tf
+++ b/code/api.tf
@@ -364,6 +364,8 @@ locals {
 
     CDN_MERCHANT_IMAGES_BASE_URL = format("https://%s", module.cdn_portal_storage.hostname)
 
+    CGN_BUCKET_CODE_LOCK_LIMIT = "101"
+
     # REDIS
     REDIS_URL      = module.redis_cache.hostname
     REDIS_PORT     = module.redis_cache.ssl_port

--- a/code/env/prod/terraform.tfvars
+++ b/code/env/prod/terraform.tfvars
@@ -16,7 +16,7 @@ backend_sku = {
   size     = "P1v3"
   capacity = 1
 }
-db_storage_mb             = 102400 # 100 GB => ~ 300 IOPS
+db_storage_mb             = 204800 # 100 GB => ~ 300 IOPS
 cert_renew_app_object_id  = "89d45b50-21e3-4cf0-b39f-9394022a44a6"
 cidr_subnet_ade_aa_mock   = ["10.0.7.0/24"]
 cidr_subnet_api           = ["10.0.2.0/24"]


### PR DESCRIPTION
This PR adds Redis cache support to io-functions-operator-search, in order to improve bucket code performance