### PR TITLE
[#IOCIT-229] Allowed all origins

### DIFF
--- a/code/spidlogin_api/postacs_policy.xml.tpl
+++ b/code/spidlogin_api/postacs_policy.xml.tpl
@@ -2,9 +2,7 @@
   <inbound>
     <cors>
       <allowed-origins>
-        %{ for origin in origins ~}
-        <origin>${origin}</origin>
-        %{ endfor ~}
+        <origin>*</origin>
       </allowed-origins>
     </cors>
     <base />


### PR DESCRIPTION
Responses should be signed by idp, security should be preserved.